### PR TITLE
Pass-on mangle options from app to minifier

### DIFF
--- a/minify.js
+++ b/minify.js
@@ -39,7 +39,7 @@ function minifyIt(type, options, content, callback)
     {
         case TYPE_JS:
 
-            callback(uglifyjs.minify(content, {mangle: options.mangle||{}, fromString: true}).code);
+            callback(uglifyjs.minify(content, {mangle: typeof options.mangle != 'undefined'? options.mangle:{}, fromString: true}).code);
 
             break;
 


### PR DESCRIPTION
When using AngularJS - javascript name mangle need to be avoided to overcome HTMLController to JS binding.

I tried to address this by passing on the mangle option from app to minifier (see the file changes):

In my app.js - used:

``` javascript
app.use(require('express-minify')({ mangle: false }));
```
