### PR TITLE
Added uglify-es support

### DIFF
--- a/minifier.js
+++ b/minifier.js
@@ -52,7 +52,8 @@ Minifier.prototype.compileAndMinify = function (assetType, minifyOptions, body, 
     result = body;
     try {
       if (!minifyOptions.noMinify) {
-        result = self.uglifyJS.minify(result, minifyOptions.uglifyOpt).code;
+		opt = Object.assign({fromString: true}, minifyOptions.uglifyOpt);
+        result = self.uglifyJS.minify(result, opt).code;
       }
     } catch (err) {
       self.handleError(err, 'minify', assetType, minifyOptions, result, callback);
@@ -152,7 +153,8 @@ Minifier.prototype.compileAndMinify = function (assetType, minifyOptions, body, 
     }
     try {
       if (!minifyOptions.noMinify) {
-        result = self.uglifyJS.minify(result, minifyOptions.uglifyOpt).code;
+        opt = Object.assign({fromString: true}, minifyOptions.uglifyOpt);
+        result = self.uglifyJS.minify(result, opt).code;
       }
     } catch (err) {
       self.handleError(err, 'minify', assetType, minifyOptions, result, callback);

--- a/minifier.js
+++ b/minifier.js
@@ -1,5 +1,3 @@
-var extend = require('util')._extend;
-
 /**
  * Test whether a module exists.
  * null for exists, false for not-exists.
@@ -54,8 +52,7 @@ Minifier.prototype.compileAndMinify = function (assetType, minifyOptions, body, 
     result = body;
     try {
       if (!minifyOptions.noMinify) {
-        opt = extend({fromString: true}, minifyOptions.uglifyOpt);
-        result = self.uglifyJS.minify(result, opt).code;
+        result = self.uglifyJS.minify(result, minifyOptions.uglifyOpt).code;
       }
     } catch (err) {
       self.handleError(err, 'minify', assetType, minifyOptions, result, callback);
@@ -155,8 +152,7 @@ Minifier.prototype.compileAndMinify = function (assetType, minifyOptions, body, 
     }
     try {
       if (!minifyOptions.noMinify) {
-        opt = extend({fromString: true}, minifyOptions.uglifyOpt);
-        result = self.uglifyJS.minify(result, opt).code;
+        result = self.uglifyJS.minify(result, minifyOptions.uglifyOpt).code;
       }
     } catch (err) {
       self.handleError(err, 'minify', assetType, minifyOptions, result, callback);


### PR DESCRIPTION
The fromString option had to be removed when using the minify method in order to support uglify-es. From what I could gather from documentation and testing, the fromString option is unnecessary (when using uglify-js and uglify-es).
I do need this change for a project and am willing to make modifications as needed (perhaps adding a compatibility flag).